### PR TITLE
Respect escaped ':' characters in CPE string

### DIFF
--- a/cpematcher/core.py
+++ b/cpematcher/core.py
@@ -1,5 +1,6 @@
 import fnmatch
 
+from .utils import split_cpe_string
 from .version import Version
 
 OR_OPERATOR = 'OR'
@@ -50,7 +51,7 @@ class CPE:
         assert cpe_str.startswith(self.cpe23_start), "Only CPE 2.3 is supported"
         cpe_str = cpe_str.replace(self.cpe23_start, '')
 
-        values = cpe_str.split(':')
+        values = split_cpe_string(cpe_str)
         if len(values) != 11:
             raise ValueError('Incomplete number of fields')
 

--- a/cpematcher/utils.py
+++ b/cpematcher/utils.py
@@ -1,0 +1,21 @@
+# heavily inspired by https://stackoverflow.com/a/21882672
+def split_cpe_string(string):
+    ret = []
+    current = []
+    itr = iter(string)
+    for ch in itr:
+        if ch == '\\':
+            try:
+                # skip the next character; it has been escaped!
+                current.append(next(itr))
+            except StopIteration:
+                pass
+        elif ch == ':':
+            # split! (add current to the list and reset it)
+            ret.append(''.join(current))
+            current = []
+        else:
+            current.append(ch)
+
+    ret.append(''.join(current))
+    return ret

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,8 +7,12 @@ class TestCPE:
     template = 'cpe:2.3:a:apache:activemq:%s:*:*:*:*:*:*:*'
 
     def test_init(self):
-        c = CPE('cpe:2.3:a:apache:activemq:4.0.1:*:*:*:*:*:*:*')
-        assert c.vendor == 'apache'
+        cpe_basic = CPE('cpe:2.3:a:apache:activemq:4.0.1:*:*:*:*:*:*:*')
+        assert cpe_basic.vendor == 'apache'
+
+        # CVE-2018-12015, NIST NVD data feed (json)
+        cpe_escaped = CPE('cpe:2.3:a:archive\\:\\:tar_project:archive\\:\\:tar:*:*:*:*:*:perl:*:*')
+        assert cpe_escaped.vendor == 'archive::tar_project'
 
     def test_init_with_invalid_cpe_str(self):
         with pytest.raises(AssertionError):


### PR DESCRIPTION
For example, some cpe strings in CVE-2018-12015 contain the product name
archive::tar (and vendor name archive::tar_project) which caused the current
implementation to fail when parsing the cpe string. This patch solves this by
implementing an escape-aware split function.

This was tested against the json CVE data feed provided by NIST NVD [1]

[1] https://nvd.nist.gov/vuln/data-feeds