### PR TITLE
Ignore .0 endings when comparing versions for equality

### DIFF
--- a/cpematcher/core.py
+++ b/cpematcher/core.py
@@ -82,7 +82,10 @@ class CPE:
             else:
                 order = [another_value, value]
 
-            if not fnmatch.fnmatch(*order):
+            if f == 'version' and '*' not in order and '*' not in order[0] and '*' not in order[1]:
+                if Version(order[0]) != Version(order[1]):
+                    return False
+            elif not fnmatch.fnmatch(*order):
                 return False
 
         version = Version(another_cpe.version)

--- a/cpematcher/version.py
+++ b/cpematcher/version.py
@@ -12,33 +12,33 @@ class Version:
         if not isinstance(other, self.__class__):
             raise NotImplementedError
 
-        return self.version == other.version
+        return self.version == other.version or self.__eq_ignore_trailing_zeros(other)
 
     def __ne__(self, other):
         if not isinstance(other, self.__class__):
             raise NotImplementedError
 
-        return self.version != other.version
+        return not self.__eq__(other)
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
             raise NotImplementedError
 
-        if self.version == other.version:
+        if self.__eq__(other):
             return False
 
         ns = natsorted([self.version, other.version])
-        return ns[0] == self.version
+        return self.__eq__(Version(ns[0]))
 
     def __gt__(self, other):
         if not isinstance(other, self.__class__):
             raise NotImplementedError
 
-        if self.version == other.version:
+        if self.__eq__(other):
             return False
 
         ns = natsorted([self.version, other.version])
-        return ns[1] == self.version
+        return self.__eq__(Version(ns[1]))
 
     def __le__(self, other):
         if not isinstance(other, self.__class__):
@@ -53,3 +53,17 @@ class Version:
 
         eq = self.__eq__(other)
         return eq or self.__gt__(other)
+
+    def __eq_ignore_trailing_zeros(self, other):
+        if not isinstance(other, self.__class__):
+            raise NotImplementedError
+
+        self_trimmed = self.version
+        while self_trimmed.endswith('.0'):
+            self_trimmed = self_trimmed[:-2]
+
+        other_trimmed = other.version
+        while other_trimmed.endswith('.0'):
+            other_trimmed = other_trimmed[:-2]
+
+        return self_trimmed == other_trimmed

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -106,6 +106,13 @@ class TestCPE:
         assert not branch_cpe.matches(CPE(self.template % '4.1.3'))
         assert not branch_cpe.matches(CPE(self.template % '4.1.4'))
 
+    def test_matches_with_reduntant_patch_level(self):
+        first = CPE(self.template % '4.2')
+        second = CPE(self.template % '4.2.0')
+
+        assert first.matches(second)
+        assert second.matches(first)
+
 
 class TestCPEOperation:
     def test_cpe_operation_with_or_operation(self):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,6 +10,12 @@ class TestVersion:
         assert Version('1.1.1') == Version('1.1.1')
         assert Version('1.1.1') != Version('1.1.2')
 
+    def test_equal_reduntant_patch_level(self):
+        assert Version('1.1') == Version("1.1.0")
+        assert Version('1') == Version('1.0.0')
+        assert Version('1.0') == Version('1.0')
+        assert Version('1.0') != Version('1.0.1')
+
     def test_inequal(self):
         assert Version('1.1.1') != Version('1.1.2')
         assert Version('1.1.1') == Version('1.1.1')


### PR DESCRIPTION
e.g.:
4.2 == 4.2.0 # True